### PR TITLE
공배수 문제 풀이

### DIFF
--- a/LV-0/공배수/tare.js
+++ b/LV-0/공배수/tare.js
@@ -1,0 +1,1 @@
+const solution = (number, n, m) => number%n || number%m ? 0 : 1;


### PR DESCRIPTION
## 연관된 이슈

<!-- close #이슈변호 -->
close #68 

## 풀이

<!-- 풀이 내용 작성 -->
- 비교연산을 이용해서 문제 풀이 했습니다.
- `number`의 나머지값이 0이 아닌 정수일 경우에는 배수에 포함되지않음으로 바로 0을 리턴하고, 0일 경우 falsy한 값임으로 우측 연산으로 넘어가 조건을 확인하게 됩니다.
- 두 조건 모두 falsy한 값 (즉, 나머지값이 0인 값) 일 경우 1을 리턴하게 됩니다.

## 배운점

<!-- 없으면 생략 가능 -->
- 다른 사람 문제 풀이를 확인해보니, `+!` 트릭 연산자라고 있더라구요
  - !로 먼저 boolean으로 반전(논리 부정 연산)
  - +로 그 boolean을 숫자형으로 변환(단항 플러스 연산)
- 여기서 단항 플러스 연산이 좀 흥미롭더라구요